### PR TITLE
CanShield module + test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
-    "rust-analyzer.checkOnSave.allTargets": false
+    "rust-analyzer.checkOnSave.allTargets": false,
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,18 @@ features = [
     "rtic",
     "can",
 ]
+
+[dev-dependencies]
+defmt-test = "0.3.0" # Logging framework for tests
+
+# This is needed to run `cargo test` on the host
+[lib]
+test = false
+
+[[test]]
+name = "should_pass"
+harness = false
+
+[[test]]
+name = "can_test"
+harness = false

--- a/examples/can_ping_pong.rs
+++ b/examples/can_ping_pong.rs
@@ -23,7 +23,7 @@ mod app {
 
     // Needed for scheduling monotonic tasks
     #[monotonic(binds = SysTick, default = true)]
-    type MyMono = DwtSystick<45_000_000>; // 180 MHz
+    type MyMono = DwtSystick<180_000_000>; // 180 MHz
 
     // Holds the shared resources (used by multiple tasks)
     // Needed even if we don't use it
@@ -56,7 +56,7 @@ mod app {
 
         // Set up the system clock.
         let rcc = _device.RCC.constrain();
-        let clocks = rcc.cfgr.sysclk(45.MHz()).freeze(); // Important: 45 MHz is the max for CAN since it has to match the APB1 clock
+        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze(); // Important: 45 MHz is the max for CAN since it has to match the APB1 clock
 
         debug!("AHB1 clock: {} Hz", clocks.hclk().to_Hz());
         debug!("APB1 clock: {} Hz", clocks.pclk1().to_Hz());
@@ -67,13 +67,13 @@ mod app {
 
         // Initialize variables for can_send
         let mut test_frame: [u8; 8] = [0; 8];
-        test_frame[1] = 1;
-        test_frame[2] = 2;
-        test_frame[3] = 3;
-        test_frame[4] = 4;
-        test_frame[5] = 5;
-        test_frame[6] = 6;
-        test_frame[7] = 7;
+        test_frame[0] = 'H' as u8;
+        test_frame[1] = 'e' as u8;
+        test_frame[2] = 'j' as u8;
+        test_frame[3] = 's' as u8;
+        test_frame[4] = 'a' as u8;
+        test_frame[5] = '!' as u8;
+        test_frame[6] = ' ' as u8;
 
         // Set up CAN device 1
         let mut can1 = {
@@ -146,7 +146,7 @@ mod app {
         let test_frame = ctx.local.test_frame;
         let id: u16 = 0x500;
 
-        test_frame[0] = COUNTER.fetch_add(1, Ordering::SeqCst) as u8;
+        test_frame[7] = COUNTER.fetch_add(1, Ordering::SeqCst) as u8;
         let frame = Frame::new_data(StandardId::new(id).unwrap(), *test_frame);
 
         info!("Sending frame with first byte: {}", test_frame[0]);

--- a/examples/canshield_echo.rs
+++ b/examples/canshield_echo.rs
@@ -1,0 +1,173 @@
+#![no_main]
+#![no_std]
+
+use stm32f446_rtic as _; // global logger + panicking-behavior + memory layout
+
+#[rtic::app(device = stm32f4xx_hal::pac, dispatchers = [USART1, USART2])]
+mod app {
+    use bxcan::{Data, Frame, StandardId};
+    use core::{
+        str,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+    use defmt::*;
+    use dwt_systick_monotonic::{DwtSystick, ExtU32};
+    use stm32f446_rtic::can_shield::CanShield;
+    use stm32f4xx_hal::{
+        can::Can,
+        gpio::{
+            gpioa::{PA11, PA12, PA5},
+            gpiob::{PB13, PB5},
+            Alternate, Output, PushPull,
+        },
+        pac::CAN1,
+        pac::CAN2,
+        prelude::*,
+    };
+
+    // Needed for scheduling monotonic tasks
+    #[monotonic(binds = SysTick, default = true)]
+    type MyMono = DwtSystick<180_000_000>; // 180 MHz
+
+    // Holds the shared resources (used by multiple tasks)
+    // Needed even if we don't use it
+    #[shared]
+    struct Shared {
+        can1: bxcan::Can<Can<CAN1, (PA12<Alternate<9>>, PA11<Alternate<9>>)>>,
+        can2: bxcan::Can<Can<CAN2, (PB13<Alternate<9>>, PB5<Alternate<9>>)>>,
+    }
+
+    // Holds the local resources (used by a single task)
+    // Needed even if we don't use it
+    #[local]
+    struct Local {
+        led: PA5<Output<PushPull>>,
+    }
+
+    // Atomic counter
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    // The init function is called in the beginning of the program
+    #[init]
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        info!("init");
+
+        // Cortex-M peripherals
+        let mut _core: cortex_m::Peripherals = ctx.core;
+
+        // Device specific peripherals
+        let mut _device: stm32f4xx_hal::pac::Peripherals = ctx.device;
+
+        // Set up the system clock.
+        let rcc = _device.RCC.constrain();
+        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze(); 
+
+        debug!("AHB1 clock: {} Hz", clocks.hclk().to_Hz());
+        debug!("APB1 clock: {} Hz", clocks.pclk1().to_Hz());
+
+        // Set up the LED. On the Nucleo-F446RE it's connected to pin PA5.
+        let gpioa = _device.GPIOA.split();
+        let gpiob = _device.GPIOB.split();
+        let led = gpioa.pa5.into_push_pull_output();
+
+        // Set up CAN device 1
+        let shield = CanShield::new_rev1(
+            gpioa.pa12,
+            gpioa.pa11,
+            gpiob.pb13,
+            gpiob.pb5,
+            _device.CAN1,
+            _device.CAN2,
+        )
+        .unwrap();
+
+        let mut can1 = shield.can1;
+        let mut can2 = shield.can2;
+
+        // enable tracing and the cycle counter for the monotonic timer
+        _core.DCB.enable_trace();
+        _core.DWT.enable_cycle_counter();
+
+        // Set up the monotonic timer
+        let mono = DwtSystick::new(&mut _core.DCB, _core.DWT, _core.SYST, clocks.hclk().to_Hz());
+
+        info!("Init done!");
+        blink::spawn_after(1.secs()).ok();
+        (Shared { can1, can2 }, Local { led }, init::Monotonics(mono))
+    }
+
+    // The idle function is called when there is nothing else to do
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        loop {
+            continue;
+        }
+    }
+
+    // The task functions are called by the scheduler
+    #[task(local = [led])]
+    fn blink(ctx: blink::Context) {
+        ctx.local.led.toggle();
+        debug!("Blink!");
+        blink::spawn_after(1.secs()).ok();
+    }
+
+    // send a meesage via CAN
+    #[task(shared = [can1, can2], priority=2)]
+    fn can_send(mut ctx: can_send::Context, _ch: u8, _data: Data) {
+        let id: u16 = 0x500;
+
+        let frame = Frame::new_data(StandardId::new(id).unwrap(), _data);
+
+        info!(
+            "Sending frame: {}",
+            str::from_utf8(&frame.clone().data().unwrap()).unwrap_or("Invalid UTF-8")
+        );
+
+        // Send the frame
+        match _ch {
+            1 => {
+                ctx.shared.can1.lock(|can1| can1.transmit(&frame).unwrap());
+            }
+            2 => {
+                ctx.shared.can2.lock(|can2| can2.transmit(&frame).unwrap());
+            }
+            _ => {
+                error!("Invalid channel");
+            }
+        }
+    }
+
+    // receive a message via CAN1
+    #[task(binds = CAN1_RX0, shared = [can1])]
+    fn can1_receive(ctx: can1_receive::Context) {
+        let mut can1 = ctx.shared.can1;
+        let frame = can1.lock(|can1| can1.receive().unwrap());
+
+        let data = frame.data().unwrap();
+
+        info!(
+            "Received frame: {}",
+            str::from_utf8(data).unwrap_or("Invalid UTF-8")
+        );
+
+        can_send::spawn(1, data.clone()).ok();
+    }
+
+    // receive a message via CAN2
+    // Note: CAN2_RX1 is used instead of CAN2_RX0 because CAN2 is set up to use FIFO 1 in the CanShield implementation
+    #[task(binds = CAN2_RX1, shared = [can2])]
+    fn can2_receive(ctx: can2_receive::Context) {
+        let mut can2 = ctx.shared.can2;
+        let frame = can2.lock(|can2| can2.receive().unwrap());
+
+        let data = frame.data().unwrap();
+
+        info!(
+            "Received frame: {}",
+            str::from_utf8(data).unwrap_or("Invalid UTF-8")
+        );
+
+        can_send::spawn(2, data.clone()).ok();
+    }
+}

--- a/examples/edge_counter.rs
+++ b/examples/edge_counter.rs
@@ -35,7 +35,7 @@ mod app {
     type MyMono = DwtSystick<48_000_000>; // 48 MHz
 
     #[init]
-    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         defmt::info!("init");
 
         // Cortex-M peripherals
@@ -74,7 +74,7 @@ mod app {
             _clocks.hclk().to_Hz(),
         );
 
-        let mut exti = _device.EXTI;
+        let exti = _device.EXTI;
 
         blink::spawn().ok();
 
@@ -83,7 +83,7 @@ mod app {
 
     // The idle function is called when there is nothing else to do
     #[idle]
-    fn idle(ctx: idle::Context) -> ! {
+    fn idle(_: idle::Context) -> ! {
         loop {
             continue;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,96 @@
 #![no_std]
+#![no_main]
 
 use defmt_rtt as _; // global logger
+use fugit as _;
 use panic_probe as _; // panic handler
-use stm32f4xx_hal as _; // memory layout
-use fugit as _; // time abstractions
+use stm32f4xx_hal as _; // memory layout // time abstractions
+
+pub mod CanShield {
+    use bxcan::filter::Mask32;
+    use stm32f4xx_hal::{
+        gpio::gpioa::{self, Parts},
+        pac::{self, Peripherals},
+        prelude::_stm32f4xx_hal_can_CanExt,
+    };
+
+    pub struct CanShield {
+        can1: bxcan::Can<stm32f4xx_hal::pac::CAN1>,
+        can2: bxcan::Can<stm32f4xx_hal::pac::CAN2>,
+    }
+
+    pub impl CanShield {
+        // pub fn new(
+        //     can1: bxcan::Can<stm32f4xx_hal::pac::CAN1>,
+        //     can2: bxcan::Can<stm32f4xx_hal::pac::CAN2>,
+        // ) -> Self {
+        //     Self { can1, can2 }
+        // }
+
+        pub fn new_rev1(device: pac::Peripherals, gpioa: Parts, gpiob: Parts) -> CanShield {
+            let mut can1 = {
+                let rx = gpioa.pa11.into_alternate::<9>();
+                let tx = gpioa.pa12.into_alternate::<9>();
+
+                let can = device.CAN1.can((tx, rx));
+
+                info!("CAN1, waiting for 11 recessive bits...");
+                bxcan::Can::builder(can)
+                    // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
+                    // Value was calculated with http://www.bittiming.can-wiki.info/
+                    .set_bit_timing(0x001b0002)
+                    .set_automatic_retransmit(true)
+                    .enable()
+            };
+
+            can1.enable_interrupts({
+                use bxcan::Interrupts as If;
+                If::FIFO0_MESSAGE_PENDING | If::FIFO0_FULL | If::FIFO0_OVERRUN
+            });
+
+            let mut filters =
+                can1.modify_filters()
+                    .enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
+
+            let mut can2 = {
+                let rx = gpiob.pb5.into_alternate::<9>();
+                let tx = gpiob.pb13.into_alternate::<9>();
+
+                let can = device.CAN2.can((tx, rx));
+
+                info!("CAN2, waiting for 11 recessive bits...");
+                bxcan::Can::builder(can)
+                    // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
+                    // Value was calculated with http://www.bittiming.can-wiki.info/
+                    .set_bit_timing(0x001b0002)
+                    .set_automatic_retransmit(true)
+                    .enable()
+            };
+
+            can2.enable_interrupts({
+                use bxcan::Interrupts as If;
+                If::FIFO0_MESSAGE_PENDING | If::FIFO0_FULL | If::FIFO0_OVERRUN
+            });
+
+            filters.set_split(14).slave_filters().enable_bank(
+                14,
+                bxcan::Fifo::Fifo1,
+                Mask32::accept_all(),
+            );
+
+            // Drop filters to leave filter configuraiton mode.
+            drop(filters);
+
+            &mut Self { can1, can2 }
+    
+        }
+
+        // pub fn can1(&mut self) -> &mut bxcan::Can<stm32f4xx_hal::pac::CAN1> {
+        //     &mut self.can1
+        // }
+
+        // pub fn can2(&mut self) -> &mut bxcan::Can<stm32f4xx_hal::pac::CAN2> {
+        //     &mut self.can2
+        // }
+    }
+}

--- a/tests/can_test.rs
+++ b/tests/can_test.rs
@@ -1,0 +1,96 @@
+#![no_std]
+#![no_main]
+
+use stm32f446_rtic as _; // global logger + panicking-behavior + memory layout
+
+#[cfg(test)]
+#[defmt_test::tests]
+mod can_tests {
+    use stm32f446_rtic::CanShield::CanShield;
+    use bxcan::filter::{self, Mask32};
+    use bxcan::{Fifo, Frame, StandardId};
+    use cortex_m_rt::entry;
+    use defmt::{assert, info};
+    use nb::block;
+    use stm32f4xx_hal::{pac, prelude::*};
+
+    #[test]
+    fn can1_call_response() {
+        let core = cortex_m::Peripherals::take().unwrap();
+        let device = pac::Peripherals::take().unwrap();
+
+        let rcc = device.RCC.constrain();
+        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze();
+
+        let gpioa = device.GPIOA.split();
+        let gpiob = device.GPIOB.split();
+
+        let mut can1 = {
+            let rx = gpioa.pa11.into_alternate::<9>();
+            let tx = gpioa.pa12.into_alternate::<9>();
+
+            let can = device.CAN1.can((tx, rx));
+
+            info!("CAN1, waiting for 11 recessive bits...");
+            bxcan::Can::builder(can)
+                // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
+                // Value was calculated with http://www.bittiming.can-wiki.info/
+                .set_bit_timing(0x001b0002)
+                .set_automatic_retransmit(true)
+                .enable()
+        };
+
+        can1.enable_interrupts({
+            use bxcan::Interrupts as If;
+            If::FIFO0_MESSAGE_PENDING | If::FIFO0_FULL | If::FIFO0_OVERRUN
+        });
+
+        let mut filters = can1
+            .modify_filters()
+            .enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
+
+        let mut can2 = {
+            let rx = gpiob.pb5.into_alternate::<9>();
+            let tx = gpiob.pb13.into_alternate::<9>();
+
+            let can = device.CAN2.can((tx, rx));
+
+            info!("CAN2, waiting for 11 recessive bits...");
+            bxcan::Can::builder(can)
+                // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
+                // Value was calculated with http://www.bittiming.can-wiki.info/
+                .set_bit_timing(0x001b0002)
+                .set_automatic_retransmit(true)
+                .enable()
+        };
+
+        can2.enable_interrupts({
+            use bxcan::Interrupts as If;
+            If::FIFO1_MESSAGE_PENDING | If::FIFO1_FULL | If::FIFO1_OVERRUN
+        });
+
+        // Split the filters evenly between CAN1 and CAN2
+        filters
+            .set_split(14)
+            .slave_filters()
+            .enable_bank(14, Fifo::Fifo1, Mask32::accept_all());
+
+        // Drop filters to leave filter configuraiton mode.
+        drop(filters);
+
+    }
+
+    #[test]
+    fn test_shield() {
+        let core = cortex_m::Peripherals::take().unwrap();
+        let device = pac::Peripherals::take().unwrap();
+
+        let rcc = device.RCC.constrain();
+        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze();
+
+        let gpioa = device.GPIOA.split();
+        let gpiob = device.GPIOB.split();
+
+        let shield = CanShield::new_rev1(device, gpioa, gpiob);
+    }
+}

--- a/tests/can_test.rs
+++ b/tests/can_test.rs
@@ -6,91 +6,91 @@ use stm32f446_rtic as _; // global logger + panicking-behavior + memory layout
 #[cfg(test)]
 #[defmt_test::tests]
 mod can_tests {
-    use stm32f446_rtic::CanShield::CanShield;
     use bxcan::filter::{self, Mask32};
     use bxcan::{Fifo, Frame, StandardId};
-    use cortex_m_rt::entry;
     use defmt::{assert, info};
-    use nb::block;
+    use stm32f446_rtic::can_shield::CanShield;
     use stm32f4xx_hal::{pac, prelude::*};
 
     #[test]
-    fn can1_call_response() {
-        let core = cortex_m::Peripherals::take().unwrap();
-        let device = pac::Peripherals::take().unwrap();
-
-        let rcc = device.RCC.constrain();
-        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze();
-
-        let gpioa = device.GPIOA.split();
-        let gpiob = device.GPIOB.split();
-
-        let mut can1 = {
-            let rx = gpioa.pa11.into_alternate::<9>();
-            let tx = gpioa.pa12.into_alternate::<9>();
-
-            let can = device.CAN1.can((tx, rx));
-
-            info!("CAN1, waiting for 11 recessive bits...");
-            bxcan::Can::builder(can)
-                // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
-                // Value was calculated with http://www.bittiming.can-wiki.info/
-                .set_bit_timing(0x001b0002)
-                .set_automatic_retransmit(true)
-                .enable()
-        };
-
-        can1.enable_interrupts({
-            use bxcan::Interrupts as If;
-            If::FIFO0_MESSAGE_PENDING | If::FIFO0_FULL | If::FIFO0_OVERRUN
-        });
-
-        let mut filters = can1
-            .modify_filters()
-            .enable_bank(0, Fifo::Fifo0, Mask32::accept_all());
-
-        let mut can2 = {
-            let rx = gpiob.pb5.into_alternate::<9>();
-            let tx = gpiob.pb13.into_alternate::<9>();
-
-            let can = device.CAN2.can((tx, rx));
-
-            info!("CAN2, waiting for 11 recessive bits...");
-            bxcan::Can::builder(can)
-                // APB1 (PCLK1): 45MHz, Bit rate: 1MBit/s, Sample Point 87.5%
-                // Value was calculated with http://www.bittiming.can-wiki.info/
-                .set_bit_timing(0x001b0002)
-                .set_automatic_retransmit(true)
-                .enable()
-        };
-
-        can2.enable_interrupts({
-            use bxcan::Interrupts as If;
-            If::FIFO1_MESSAGE_PENDING | If::FIFO1_FULL | If::FIFO1_OVERRUN
-        });
-
-        // Split the filters evenly between CAN1 and CAN2
-        filters
-            .set_split(14)
-            .slave_filters()
-            .enable_bank(14, Fifo::Fifo1, Mask32::accept_all());
-
-        // Drop filters to leave filter configuraiton mode.
-        drop(filters);
-
-    }
-
-    #[test]
+    // Requres connecting the CanShield to a bus with another CAN device running 
+    // canshield_echo example (examples/canshield_echo.rs)
     fn test_shield() {
         let core = cortex_m::Peripherals::take().unwrap();
         let device = pac::Peripherals::take().unwrap();
 
         let rcc = device.RCC.constrain();
-        let clocks = rcc.cfgr.sysclk(180.MHz()).freeze();
+        let _clocks = rcc.cfgr.sysclk(180.MHz()).freeze();
 
         let gpioa = device.GPIOA.split();
         let gpiob = device.GPIOB.split();
 
-        let shield = CanShield::new_rev1(device, gpioa, gpiob);
+        let shield = CanShield::new_rev1(
+            gpioa.pa12,
+            gpioa.pa11,
+            gpiob.pb13,
+            gpiob.pb5,
+            device.CAN1,
+            device.CAN2,
+        )
+        .unwrap();
+
+        info!("CAN shield initialized");
+
+        let mut can1 = shield.can1;
+        let mut can2 = shield.can2;
+
+        let mut test_frame1: [u8; 8] = [0; 8];
+        test_frame1[0] = 'H' as u8;
+        test_frame1[1] = 'e' as u8;
+        test_frame1[2] = 'j' as u8;
+        test_frame1[3] = 's' as u8;
+        test_frame1[4] = 'a' as u8;
+        test_frame1[5] = '!' as u8;
+        test_frame1[6] = ' ' as u8;
+        test_frame1[7] = '1' as u8;
+
+        let mut test_frame2: [u8; 8] = [0; 8];
+        test_frame2[0] = 'H' as u8;
+        test_frame2[1] = 'e' as u8;
+        test_frame2[2] = 'l' as u8;
+        test_frame2[3] = 'l' as u8;
+        test_frame2[4] = 'o' as u8;
+        test_frame2[5] = '!' as u8;
+        test_frame2[6] = ' ' as u8;
+        test_frame2[7] = '2' as u8;
+
+        let id_frame1 = StandardId::new(0x111).unwrap();
+        let id_frame2 = StandardId::new(0x222).unwrap();
+        let id_reply = StandardId::new(0x500).unwrap();
+
+        let tx_frame1 = Frame::new_data(id_frame1, test_frame1);
+        let tx_frame2 = Frame::new_data(id_frame2, test_frame2);
+
+        info!("Sending frame 1: {:?}", tx_frame1);
+        can1.transmit(&tx_frame1).unwrap();
+
+        info!("Sending frame 2: {:?}", tx_frame2);
+        can2.transmit(&tx_frame2).unwrap();
+
+        loop {
+            if let Ok(rx_frame1) = can1.receive() {
+                info!("Received frame 1: {:?}", rx_frame1);
+                assert_eq!(rx_frame1.id(), id_reply.into());
+                assert_eq!(rx_frame1.data().unwrap().clone(), test_frame1.into());
+                info!("CAN1 frame match successfull");
+                break;
+            }
+        }
+
+        loop {
+            if let Ok(rx_frame2) = can2.receive() {
+                info!("Received frame 2: {:?}", rx_frame2);
+                assert_eq!(rx_frame2.id(), id_reply.into());
+                assert_eq!(rx_frame2.data().unwrap().clone(), test_frame2.into());
+                info!("CAN2 frame match successfull");
+                break;
+            }
+        }
     }
 }

--- a/tests/should_pass.rs
+++ b/tests/should_pass.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use stm32f446_rtic as _; // global logger + panicking-behavior + memory layout
+
+#[cfg(test)]
+#[defmt_test::tests]
+mod should_pass {
+    use defmt::{
+        info,
+        assert
+    };
+
+    #[test]
+    fn should_pass() {
+        info!("Hello, world!");
+        assert!(true)
+    }
+
+}


### PR DESCRIPTION
Added module for configuring CAN shield.
Usage example: `examples/canshield_echo.rs`
Added test: `tests/can_test.rs`, needs another microcontroller running above example.